### PR TITLE
Enable Solidity optimizer

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -135,13 +135,14 @@ module.exports = {
     solc: {
       version: "0.8.6", // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
-      // settings: {          // See the solidity docs for advice about optimization and evmVersion
-      //  optimizer: {
-      //    enabled: false,
-      //    runs: 200
-      //  },
-      //  evmVersion: "byzantium"
-      // }
+      settings: {
+        // See the solidity docs for advice about optimization and evmVersion
+        optimizer: {
+          enabled: true,
+          runs: 200,
+        },
+        //  evmVersion: "byzantium"
+      },
     },
   },
 };


### PR DESCRIPTION
Resolves #22 

I have tested all the contracts without the optimizer, with the optimizer set to 200 runs and with the optimizer set to 1000 runs.
A detailed breakdown on how much gas each function/deploy costs is available here: [Agora optimization.pdf](https://github.com/AgoraSpaceDAO/agora-contracts/files/6983859/Agora.optimization.pdf)

Key takeaways:
- optimization on (200 runs) vs optimization off
  - there's a huge reduction in deploy costs
  - there's a noticeable reduction in function call costs
- optimization on (1000 runs) vs optimization on (200 runs)
  - there's a noticeable increase in deploy costs
  - there's a negligible reduction in function call costs, except in Agora Space Factory, where there is a noticeable increase instead

My thoughts:
The best solution would be to use the optimizer with 200 runs. There's no real benefit from using a different run value (I've tried with 1 run too, but decided not to include the results as they were almost identical to the results with 200 runs). That's the best solution for the Factory contract too, and since it contains the bytecode of the contracts that it deploys, it deploys them with the same optimization settings.